### PR TITLE
fix: some error checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ currently deployed version.
 
 ## Engines
 
-There are currently to supported deployment engines:
+There are currently two supported deployment engines:
 
-- [AWS Lambda](https://aws.amazon.com/lambda/) (type: `lambda) - with the code packaged as a Docker 
+- [AWS Lambda](https://aws.amazon.com/lambda/) (type: `lambda`) - with the code packaged as a Docker 
   image. Version is the image tag.
-- [AWS ECS](https://aws.amazon.com/ecs/) (type: `ecs) - with the code packaged as a Docker image. 
+- [AWS ECS](https://aws.amazon.com/ecs/) (type: `ecs`) - with the code packaged as a Docker image. 
   Version is the image tag.
 
 ## Contributing

--- a/deployments/config.go
+++ b/deployments/config.go
@@ -4,7 +4,7 @@ import (
 	"github.com/DandyDev/ploy/engine"
 	"github.com/mitchellh/mapstructure"
 	"gopkg.in/yaml.v3"
-	"io/ioutil"
+	"os"
 )
 
 type Deployments struct {
@@ -14,7 +14,7 @@ type Deployments struct {
 func LoadDeploymentsFromFile(cliArgs []string) ([]engine.Deployment, error) {
 	deploymentsConfigPath := cliArgs[0]
 	deploymentsConfig := &Deployments{}
-	bytes, err := ioutil.ReadFile(deploymentsConfigPath)
+	bytes, err := os.ReadFile(deploymentsConfigPath)
 	if err != nil {
 		return nil, err
 	}
@@ -23,10 +23,13 @@ func LoadDeploymentsFromFile(cliArgs []string) ([]engine.Deployment, error) {
 		return nil, err
 	}
 	deployments := make([]engine.Deployment, 0, len(deploymentsConfig.Deployments))
-	for _, d := range deploymentsConfig.Deployments {
-		deploymentEngine := engine.GetEngine(d["type"].(string))
+	for _, deployment := range deploymentsConfig.Deployments {
+		deploymentEngine, err := engine.GetEngine(deployment["type"].(string))
+		if err != nil {
+			return nil, err
+		}
 		deploymentConfig := deploymentEngine.ResolveConfigStruct()
-		err = mapstructure.Decode(d, deploymentConfig)
+		err = mapstructure.Decode(deployment, deploymentConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/engine/core.go
+++ b/engine/core.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
@@ -44,10 +45,10 @@ func ListEngines() []string {
 	return keys
 }
 
-func GetEngine(id string) DeploymentEngine {
+func GetEngine(id string) (DeploymentEngine, error) {
 	engine, ok := engineRegistry[id]
 	if !ok {
-		panic("Unknown deployment engine " + id)
+		return nil, fmt.Errorf("unknown deployment engine %s", id)
 	}
-	return engine
+	return engine, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.15.11
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.18.9
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.23.2
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/spf13/cobra v1.5.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -24,7 +25,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.7 // indirect
 	github.com/aws/smithy-go v1.11.3 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect


### PR DESCRIPTION
This changes cobra.CheckErr (which exits on the spot) to returning error objects which are handled in the calling site.