### PR TITLE
feature: pre-deployment-script option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ go.work
 
 dist/
 /*.sh
+
+ploy

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ deployments:
     type: lambda
     version: v2
     version-environment-key: VERSION # optional, updates the given environment variable with the version when deploying
-    post-deploy-command: ["./my-script.sh", "arg1", "arg2"] # optional, runs the specified command after succesful deployment. The deployed version is availabe as the $VERSION environment variable 
+    pre-deploy-command: ["./my-script.sh", "arg1", "arg2"] # optional, runs the specified command before deployment. The to be deployed version is available as the $VERSION environment variable 
+    post-deploy-command: ["./my-script.sh", "arg1", "arg2"] # optional, runs the specified command after successful deployment. The deployed version is available as the $VERSION environment variable 
   - id: my-container # in case of ECS, this is the service name
     type: ecs
     cluster: my-cluster

--- a/engine/core.go
+++ b/engine/core.go
@@ -11,6 +11,7 @@ type Deployment interface {
 	Id() string
 	Type() string
 	Version() string
+	PreDeployCommand() []string
 	PostDeployCommand() []string
 	SetVersion(version string)
 }
@@ -19,6 +20,7 @@ type BaseDeploymentConfig struct {
 	Id_                string   `mapstructure:"id"`
 	Type_              string   `mapstructure:"type"`
 	Version_           string   `mapstructure:"version"`
+	PreDeployCommand_  []string `mapstructure:"pre-deploy-command,omitempty"`
 	PostDeployCommand_ []string `mapstructure:"post-deploy-command,omitempty"`
 }
 
@@ -32,6 +34,10 @@ func (d BaseDeploymentConfig) Type() string {
 
 func (d BaseDeploymentConfig) Version() string {
 	return d.Version_
+}
+
+func (d BaseDeploymentConfig) PreDeployCommand() []string {
+	return d.PreDeployCommand_
 }
 
 func (d BaseDeploymentConfig) PostDeployCommand() []string {

--- a/engine/ecs.go
+++ b/engine/ecs.go
@@ -51,7 +51,7 @@ func (engine *ECSDeploymentEngine) Deploy(config Deployment, p func(string, ...a
 	taskDefinitionOutput, err := engine.ECSClient.DescribeTaskDefinition(context.Background(), &ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: taskDefinitionArn,
 	})
-	p("Registring new task definition for '%s' with version '%s'...", *taskDefinitionOutput.TaskDefinition.Family, ecsConfig.Version())
+	p("Registering new task definition for '%s' with version '%s'...", *taskDefinitionOutput.TaskDefinition.Family, ecsConfig.Version())
 	registerTaskDefinitionOutput, err := engine.ECSClient.RegisterTaskDefinition(context.Background(), generateRegisterTaskDefinitionInput(taskDefinitionOutput.TaskDefinition, ecsConfig.Version(), ecsConfig.VersionEnvironmentKey))
 	if err != nil {
 		return err
@@ -112,6 +112,7 @@ func generateRegisterTaskDefinitionInput(taskDefinition *types.TaskDefinition, v
 
 // TODO: error handling if service can't be found or multiple services found (shouldn't be possible with list of one?).
 // TODO: deal with task definitions without a service (i.e. one-off tasks). Maybe separate out into a separate engine?
+
 func (engine *ECSDeploymentEngine) CheckVersion(config Deployment) (string, error) {
 	ecsConfig := config.(*EcsDeployment)
 	services, err := engine.ECSClient.DescribeServices(


### PR DESCRIPTION
This commit adds the ability to configure a pre-deployment-script, which runs before any deployment.
Any output to STDOUT will be streamed to the console, same for the post-deployment-script.
