### PR TITLE
chore: remove fetch depth 0 from checkout action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - name: Force fetch upstream tags
         run: git fetch --tags --force


### PR DESCRIPTION
Zero means: retrieve _all_ commits, where we actually only need a single one. The default is 1
